### PR TITLE
Fix doc typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ An `undefined` property, not populated by the parser, to identify feeds and entr
 
 ### enclosure()
 
-- `href` `str()`
 - `length` `str()`
 - `type` `str()`
+- `url` `str()`
 
 ### entry()
 


### PR DESCRIPTION
Fix enclosure property-name: `href` -> `url`.