### PR TITLE
Added lastBuildDate mappings to updated, to support wordpress RSS feeds

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,26 +84,30 @@ function Pickup (opts) {
     if (key === undefined) return
 
     if (state.image && name === 'url') key = 'image'
-
+    
     const isSet = current[key] !== undefined
 
-    // First wins, except 'content:encoded' summary of reasonable length.
-
     if (isSet) {
-      const shouldOverride = () => {
-        if (key === 'summary') {
+      if (key === 'summary') {
+        // First wins, except 'content:encoded' summary of reasonable length.
+        const shouldSummaryOverride = () => {
           return name === 'content:encoded' && t.length < 4096
         }
-        return false
+        if (!shouldSummaryOverride()) {
+          return
+        }
       }
-
-      if (!shouldOverride()) {
-        return
+      if (key === 'updated') {
+        // pubDate overrides lastBuildDate.
+        const shouldUpdatedOverride = () => {
+          return name === 'pubDate'
+        }
+        if (!shouldUpdatedOverride()) {
+          return
+        }
       }
-
       debug('overriding %s with %s', key, name)
     }
-
     current[key] = t
   }
 

--- a/lib/mappings.js
+++ b/lib/mappings.js
@@ -15,6 +15,7 @@ module.exports = {
     ['language', 'language'],
     ['link', 'link'],
     ['pubDate', 'updated'],
+    ['lastBuildDate', 'updated'],
     ['title', 'title'],
     ['ttl', 'ttl']
   ]),

--- a/test/pubDateLastBuildDate.js
+++ b/test/pubDateLastBuildDate.js
@@ -4,7 +4,26 @@
 
 const parse = require('./lib/parse')
 const test = require('tap').test
-
+test('updated populated by lastBuildDate', function (t) {
+    const xml = [
+      '<rss><channel>',
+      '<lastBuildDate>2018-12-27T23:29:49+0000</lastBuildDate>',
+      '</channel></rss>'
+    ].join()
+    const wanted = [
+      ['feed', {
+        updated: '2018-12-27T23:29:49+0000'
+      }],
+      ['readable'],
+      ['finish'],
+      ['end']
+    ]
+    parse({ t: t, xml: xml, wanted: wanted }, (er) => {
+      t.ok(!er)
+      t.end()
+    })
+  })
+  
 test('pubDate overrides lastBuildDate', function (t) {
   const xml = [
     '<rss><channel>',
@@ -25,16 +44,16 @@ test('pubDate overrides lastBuildDate', function (t) {
     t.end()
   })
 })
-
-test('updated populated by lastBuildDate', function (t) {
+test('pubDate overrides lastBuildDate in any order', function (t) {
   const xml = [
     '<rss><channel>',
+    '<pubDate>2018-12-27T23:29:50+0000</pubDate>',
     '<lastBuildDate>2018-12-27T23:29:49+0000</lastBuildDate>',
     '</channel></rss>'
   ].join()
   const wanted = [
     ['feed', {
-      updated: '2018-12-27T23:29:49+0000'
+      updated: '2018-12-27T23:29:50+0000'
     }],
     ['readable'],
     ['finish'],
@@ -45,3 +64,4 @@ test('updated populated by lastBuildDate', function (t) {
     t.end()
   })
 })
+

--- a/test/pubDateLastBuildDate.js
+++ b/test/pubDateLastBuildDate.js
@@ -5,25 +5,25 @@
 const parse = require('./lib/parse')
 const test = require('tap').test
 test('updated populated by lastBuildDate', function (t) {
-    const xml = [
-      '<rss><channel>',
-      '<lastBuildDate>2018-12-27T23:29:49+0000</lastBuildDate>',
-      '</channel></rss>'
-    ].join()
-    const wanted = [
-      ['feed', {
-        updated: '2018-12-27T23:29:49+0000'
-      }],
-      ['readable'],
-      ['finish'],
-      ['end']
-    ]
-    parse({ t: t, xml: xml, wanted: wanted }, (er) => {
-      t.ok(!er)
-      t.end()
-    })
+  const xml = [
+    '<rss><channel>',
+    '<lastBuildDate>2018-12-27T23:29:49+0000</lastBuildDate>',
+    '</channel></rss>'
+  ].join()
+  const wanted = [
+    ['feed', {
+      updated: '2018-12-27T23:29:49+0000'
+    }],
+    ['readable'],
+    ['finish'],
+    ['end']
+  ]
+  parse({ t: t, xml: xml, wanted: wanted }, (er) => {
+    t.ok(!er)
+    t.end()
   })
-  
+})
+
 test('pubDate overrides lastBuildDate', function (t) {
   const xml = [
     '<rss><channel>',
@@ -44,6 +44,7 @@ test('pubDate overrides lastBuildDate', function (t) {
     t.end()
   })
 })
+
 test('pubDate overrides lastBuildDate in any order', function (t) {
   const xml = [
     '<rss><channel>',
@@ -64,4 +65,3 @@ test('pubDate overrides lastBuildDate in any order', function (t) {
     t.end()
   })
 })
-

--- a/test/pubDateLastBuildDate.js
+++ b/test/pubDateLastBuildDate.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// check order of presidence between pubDate and lastBuildDate for the 'updated' mapping
+
+const parse = require('./lib/parse')
+const test = require('tap').test
+
+test('pubDate overrides lastBuildDate', function (t) {
+  const xml = [
+    '<rss><channel>',
+    '<lastBuildDate>2018-12-27T23:29:49+0000</lastBuildDate>',
+    '<pubDate>2018-12-27T23:29:50+0000</pubDate>',
+    '</channel></rss>'
+  ].join()
+  const wanted = [
+    ['feed', {
+      updated: '2018-12-27T23:29:50+0000'
+    }],
+    ['readable'],
+    ['finish'],
+    ['end']
+  ]
+  parse({ t: t, xml: xml, wanted: wanted }, (er) => {
+    t.ok(!er)
+    t.end()
+  })
+})
+
+test('updated populated by lastBuildDate', function (t) {
+  const xml = [
+    '<rss><channel>',
+    '<lastBuildDate>2018-12-27T23:29:49+0000</lastBuildDate>',
+    '</channel></rss>'
+  ].join()
+  const wanted = [
+    ['feed', {
+      updated: '2018-12-27T23:29:49+0000'
+    }],
+    ['readable'],
+    ['finish'],
+    ['end']
+  ]
+  parse({ t: t, xml: xml, wanted: wanted }, (er) => {
+    t.ok(!er)
+    t.end()
+  })
+})


### PR DESCRIPTION
It appears that in the wonderful world of RSS inconsistencies, some feeds do not have `pubDate` in their `<channel>`s.  But they do have `lastBuildDate`, which is near as damn-it the same thing. 

Here's a feed which does this:
https://answermethispodcast.com/feed/
