### PR TITLE
Trim text and cdata

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,13 +154,13 @@ function Pickup (opts) {
 
   parser.ontext = (text) => {
     const t = text.trim()
-    const state = this.state
 
     if (t.length === 0) {
-      debug('%s: discarding text: whitespace', state.name)
+      debug('discarding text: whitespace')
       return
     }
 
+    const state = this.state
     const current = state.entry || state.feed
 
     if (!current || !state.map) return

--- a/index.js
+++ b/index.js
@@ -152,8 +152,15 @@ function Pickup (opts) {
 
   const parser = new sax.SaxesParser(opts ? opts.parser : null)
 
-  parser.ontext = (t) => {
+  parser.ontext = (text) => {
+    const t = text.trim()
     const state = this.state
+
+    if (t.length === 0) {
+      debug('%s: discarding text: whitespace', state.name)
+      return
+    }
+
     const current = state.entry || state.feed
 
     if (!current || !state.map) return
@@ -165,13 +172,6 @@ function Pickup (opts) {
     if (state.image && state.name === 'url') key = 'image'
 
     const isSet = current[key] !== undefined
-
-    const trimmed = t.trim()
-
-    if (trimmed.length === 0) {
-      debug('%s: discarding text: whitespace', state.name)
-      return
-    }
 
     if (isSet) {
       if (!state.takesPrecedence()) {

--- a/index.js
+++ b/index.js
@@ -5,13 +5,14 @@
 exports = module.exports = Pickup
 
 const attribute = require('./lib/attribute')
-const debug = require('util').debuglog('pickup')
 const mappings = require('./lib/mappings')
 const os = require('os')
 const sax = require('saxes')
-const util = require('util')
+const { debuglog, inherits } = require('util')
 const { StringDecoder } = require('string_decoder')
 const { Transform } = require('readable-stream')
+
+const debug = debuglog('pickup')
 
 function Entry (
   author,
@@ -126,7 +127,6 @@ function encodingFromOpts (opts) {
   return encodingFromString(str)
 }
 
-util.inherits(Pickup, Transform)
 function Pickup (opts) {
   if (!(this instanceof Pickup)) return new Pickup(opts)
   Transform.call(this, opts)
@@ -155,29 +155,42 @@ function Pickup (opts) {
   parser.ontext = (t) => {
     const state = this.state
     const current = state.entry || state.feed
+
     if (!current || !state.map) return
 
     let key = state.key()
+
     if (key === undefined) return
 
     if (state.image && state.name === 'url') key = 'image'
 
     const isSet = current[key] !== undefined
 
+    const trimmed = t.trim()
+
+    if (trimmed.length === 0) {
+      debug('%s: discarding text: whitespace', state.name)
+      return
+    }
+
     if (isSet) {
       if (!state.takesPrecedence()) {
         return
       } else if (state.name === 'content:encoded' && t.length > 4096) {
+        debug('%s: discarding text: too long', state.name)
         return
       }
+
+      debug('%s: taking precedence: ( %s, %s )', state.name, key, t)
     }
 
     current[key] = t
   }
 
-  parser.oncdata = (d) => {
-    parser.ontext(d)
-  }
+  // Not differentiating between cdata and text, whichever comes first wins.
+  // This might be a mistake, but I don’t see a clear-cut alternative.
+
+  parser.oncdata = parser.ontext
 
   parser.onerror = (er) => {
     debug('error: %s', er)
@@ -222,6 +235,8 @@ function Pickup (opts) {
   this.parser = parser
 }
 
+inherits(Pickup, Transform)
+
 Pickup.prototype.objectMode = function () {
   return this._readableState.objectMode
 }
@@ -240,9 +255,8 @@ Pickup.prototype.imageopen = function () {
 
 Pickup.prototype.entryclose = function () {
   const entry = this.state.entry
-  if (!entry) return
 
-  debug('entry: %o', entry)
+  if (!entry) return
 
   if (!this.eventMode) {
     if (this.objectMode()) {
@@ -259,9 +273,8 @@ Pickup.prototype.entryclose = function () {
 
 Pickup.prototype.feedclose = function () {
   const feed = this.state.feed
-  if (!feed) return
 
-  debug('feed: %O', feed)
+  if (!feed) return
 
   if (!this.eventMode) {
     if (this.objectMode()) {
@@ -288,6 +301,7 @@ function free (parser) {
 }
 
 Pickup.prototype._flush = function (cb) {
+  debug('flushing')
   this.parser.close()
   free(this.parser)
 
@@ -304,6 +318,7 @@ Pickup.prototype._flush = function (cb) {
 function cribEncoding (str) {
   const enc = str.split('encoding')[1]
   const def = 'utf8'
+
   if (!enc) return def
 
   if (enc.trim()[0] === '=') {
@@ -339,7 +354,7 @@ exports.Pickup = Pickup
 exports.Feed = Feed
 exports.Entry = Entry
 
-// Extending surface area for testing.
+// Extending surface area when testing.
 
 if (process.mainModule.filename.match(/test/) !== null) {
   exports.extend = function (origin, add) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickup",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Transform RSS or Atom XML to JSON",
   "main": "index.js",
   "directories": {

--- a/test/cdata.js
+++ b/test/cdata.js
@@ -26,3 +26,26 @@ test('media-thumbnail', (t) => {
     t.end()
   })
 })
+
+test('whitespace', (t) => {
+  const xml =
+    `<rss><channel>
+       <item>
+         <content:encoded>
+           <![CDATA[spacetime is four dimensional]]>
+         </content:encoded>
+       </item>'
+    </channel></rss>`
+
+  const wanted = [
+    ['entry', pickup.entry({ summary: 'spacetime is four dimensional' })],
+    ['feed', {}],
+    ['finish'],
+    ['end']
+  ]
+
+  parse({ t: t, xml: xml, wanted: wanted }, (er) => {
+    t.ok(!er)
+    t.end()
+  })
+})

--- a/test/cdata.js
+++ b/test/cdata.js
@@ -11,7 +11,7 @@ test('media-thumbnail', (t) => {
     `<rss><channel>
        <item>
          <description><![CDATA[<sender>John Smith</sender>]]></description>
-       </item>'
+       </item>
     </channel></rss>`
 
   const wanted = [
@@ -34,7 +34,7 @@ test('whitespace', (t) => {
          <content:encoded>
            <![CDATA[spacetime is four dimensional]]>
          </content:encoded>
-       </item>'
+       </item>
     </channel></rss>`
 
   const wanted = [


### PR DESCRIPTION
Saxes handling whitespace differently caused problems collecting `CDATA` text, when the tag is surrounded by whitespace. Needs test, but this is the fix, adjusting debug logging on the side.